### PR TITLE
Skip files/paths mapped in .gitignore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 pandas
+gitignore-parser==0.0.6

--- a/setup.py
+++ b/setup.py
@@ -8,26 +8,25 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     version='1.77',
     license='MIT',
-    description='A simple module which finds files with different secrets keys present inside a directory. Secrets '
-                'derived from 120 different signatures.',
-    author='Valay Dave',
+    description='A simple module which finds files with different secrets keys present inside a directory.'
+                'Secrets derived from 120 different signatures.',
+    author='Valay Dave',                   
     include_package_data=True,
     author_email='valaygaurang@gmail.com',
     url='https://github.com/valayDave/tell-me-your-secrets',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    # Keywords that define your package best
+    long_description_content_type='text/markdown',
     keywords=['Security', 'SSH', 'Secret Keys', 'SysAdmin'],
     install_requires=[
         'pyyaml',
         'pandas',
+        'gitignore-parser',
     ],
     python_requires='>=3.4',
     entry_points={
         'console_scripts': ['tell-me-your-secrets=tell_me_your_secrets.__main__:run_service'],
     },
     classifiers=[
-        # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Topic :: Security',

--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -229,7 +229,7 @@ class SignatureRecognizer:
             return False
 
     def gitignore_check(self, matcher: str) -> bool:
-        return self.use_gitignore and not self.gitignore_matcher(matcher)
+        return self.use_gitignore and self.gitignore_matcher(matcher)
 
     def is_ignored_path(self, dir_path: str) -> bool:
         if len([matched_path for matched_path in self.blacklisted_paths if matched_path in dir_path]) > 0:

--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -114,13 +114,13 @@ class SimpleMatch(Signature):
 
 
 class SignatureRecognizer:
-    def __init__(self, config_object: dict, path: str, use_gitignore: bool, print_results=VERBOSE_OUTPUT,
+    def __init__(self, config_object: dict, search_path: str, use_gitignore: bool, print_results=VERBOSE_OUTPUT,
                  write_results=SAVE_ON_COMPLETE, output_path=DEFAULT_OUTPUT_PATH, user_filters: list = []):
         self.config = config_object  # todo: Fix this Later.
-        self.path = path
+        self.search_path = search_path
         self.use_gitignore = use_gitignore
         if use_gitignore:
-            gitignore_file = os.path.join(path, '.gitignore')
+            gitignore_file = os.path.join(search_path, '.gitignore')
             if os.path.exists(gitignore_file):
                 module_logger.debug(f'Using gitignore file: {gitignore_file}')
                 self.gitignore_matcher = parse_gitignore(gitignore_file)
@@ -136,7 +136,7 @@ class SignatureRecognizer:
         self.output_path = output_path
         # $ Make Configuration Objects For each of the Signatures in the Config Object.
         self.load_config()
-        module_logger.info(f'Secret Sniffer Initialised For Path: {path}')
+        module_logger.info(f'Secret Sniffer Initialised For Path: {search_path}')
 
     # $ Create the signature objects over here. 
     def load_config(self):
@@ -167,7 +167,7 @@ class SignatureRecognizer:
         }
     
     def find_vulnerable_files(self):
-        filtered_files = self.get_files(self.path)
+        filtered_files = self.get_files(self.search_path)
         for possible_compromised_path in filtered_files:
             # $ todo : Create more modular processing of files. 
             # $ todo : Create a threaded version of the processing of files
@@ -184,7 +184,7 @@ class SignatureRecognizer:
                     module_logger.info(f'Signature Matched : {signature_name} | On Part : {signature_part} | With '
                                        f'File : {possible_compromised_path}')
 
-        module_logger.info(f'Found {len(self.matched_signatures)} matches from the path {self.path}')
+        module_logger.info(f'Found {len(self.matched_signatures)} matches from the search_path {self.search_path}')
         if self.write_results:
             self.write_results_to_file()
     
@@ -237,14 +237,13 @@ class SignatureRecognizer:
 
         if self.gitignore_check(dir_path):
             module_logger.debug(f'Skipping path {dir_path} due to gitignored')
-
             return False
 
         return True
 
-    def get_files(self, path: str) -> list:
+    def get_files(self, search_path: str) -> list:
         f = []
-        for (dir_path, dir_names, filenames) in os.walk(path):
+        for (dir_path, dir_names, filenames) in os.walk(search_path):
             # Todo : Over here the Engine Will Test for the Different Types and other things. 
             if not self.check_accepted_path(dir_path):
                 continue
@@ -253,13 +252,13 @@ class SignatureRecognizer:
         return f
 
     
-def init_signature(config: dict, path: str, write_path: str, user_filters: list, use_gitignore: bool):
+def init_signature(config: dict, search_path: str, write_path: str, user_filters: list, use_gitignore: bool):
     # $ todo : Create the signature Object with the methods that
     if write_path:
-        return SignatureRecognizer(config, path, use_gitignore, write_results=True, output_path=write_path,
+        return SignatureRecognizer(config, search_path, use_gitignore, write_results=True, output_path=write_path,
                                    user_filters=user_filters)
 
-    return SignatureRecognizer(config, path, use_gitignore, user_filters=user_filters)
+    return SignatureRecognizer(config, search_path, use_gitignore, user_filters=user_filters)
 
 # $ Gets all subpaths for the directory. 
 

--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -212,6 +212,7 @@ class SignatureRecognizer:
             return False
 
         if self.gitignore_check(file_path):
+            module_logger.debug(f'Skipping file {file_path} due to gitignored')
             return True
 
         # $ Check if if File is is in blacklisted extension
@@ -235,6 +236,8 @@ class SignatureRecognizer:
             return False
 
         if self.gitignore_check(dir_path):
+            module_logger.debug(f'Skipping path {dir_path} due to gitignored')
+
             return False
 
         return True

--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -120,7 +120,10 @@ class SignatureRecognizer:
         self.path = path
         self.use_gitignore = use_gitignore
         if use_gitignore:
-            self.gitignore_matcher = parse_gitignore(os.path.join(path, '.gitignore'))
+            gitignore_file = os.path.join(path, '.gitignore')
+            if os.path.exists(gitignore_file):
+                module_logger.debug(f'Using gitignore file: {gitignore_file}')
+                self.gitignore_matcher = parse_gitignore(gitignore_file)
         self.blacklisted_extensions = config_object.get('blacklisted_extensions', [])
         self.blacklisted_paths = [path.format(sep=os.path.sep) for path in config_object['blacklisted_paths']]
         self.red_flag_extensions = config_object.get('red_flag_extensions', [])

--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -231,25 +231,26 @@ class SignatureRecognizer:
     def gitignore_check(self, matcher: str) -> bool:
         return self.use_gitignore and not self.gitignore_matcher(matcher)
 
-    def check_accepted_path(self, dir_path: str) -> bool:
+    def is_ignored_path(self, dir_path: str) -> bool:
         if len([matched_path for matched_path in self.blacklisted_paths if matched_path in dir_path]) > 0:
-            return False
+            return True
 
         if self.gitignore_check(dir_path):
             module_logger.debug(f'Skipping path {dir_path} due to gitignored')
-            return False
+            return True
 
-        return True
+        return False
 
     def get_files(self, search_path: str) -> list:
-        f = []
+        files = []
         for (dir_path, dir_names, filenames) in os.walk(search_path):
             # Todo : Over here the Engine Will Test for the Different Types and other things. 
-            if not self.check_accepted_path(dir_path):
+            if self.is_ignored_path(dir_path):
                 continue
+
             adding_files = [os.path.abspath(os.path.join(dir_path,file)) for file in filenames if not self.check_skippable_file(os.path.abspath(os.path.join(dir_path,file)))]
-            f.extend(adding_files)
-        return f
+            files.extend(adding_files)
+        return files
 
     
 def init_signature(config: dict, search_path: str, write_path: str, user_filters: list, use_gitignore: bool):


### PR DESCRIPTION
Another use case we had is to ignore things that are within `.gitignore` files. 

This change brings the ability to load the `.gitignore` file from the root of the scan dir by providing the `-g` flag

It doesn't support recursively loading as it scans. e.g. if there is a `.gitignore` file nested in the scan dir it won't handle that.

## Test bed

```
malachi@pulsar scan-test $ tree
.
├── ignore-dir
│   └── ignored
├── ignore-file
├── scan-dir
│   └── scan-file
└── scan-file
```

```
malachi@pulsar scan-test $ cat .gitignore 
/ignore-dir/
/ignore-file
```

Run with `python -m tell_me_your_secrets -v -g /path/to/scan-test/`


Also brings readability improvements by switching negated conditions,  variable clarity, and more typo fixes.
