### PR TITLE
Add basic PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Proposed change
+<!--
+  Describe the change at a high-level.
+-->
+
+## How to test the change
+<!--
+  Include the steps required to test the change locally if applicable.
+-->
+
+## Checklist
+<!--
+  Please consider the following when submitting code changes.
+
+  Note: You can check the boxes once you submit, or put an x in the [ ]
+
+  like [x]
+-->
+
+-   [ ] Tests have been added to verify that the new code works (if possible)
+-   [ ] Documentation has been updated to reflect changes


### PR DESCRIPTION
In order to help people contribute we should have a PR template that helps them:

- Describe the problem the change is solving
- How for PR reviewers to verify the changes
- A basic checklist of somethings they should consider


See: https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository