### PR TITLE
Add test to ensure default config is valid

### DIFF
--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -136,7 +136,7 @@ class SignatureRecognizer:
         self.signatures = self.load_signatures(config_object.get('signatures', {}), user_filters)
         module_logger.info(f'Secret Sniffer Initialised For Path: {search_path}')
 
-    # $ Create the signature objects over here. 
+    # $ Create the signature objects over here.
     @staticmethod
     def load_signatures(raw_signatures: dict, user_filters: list) -> list:
         chosen_configs = []
@@ -149,20 +149,20 @@ class SignatureRecognizer:
                 if len([filtered_val for filtered_val in user_filters if str(filtered_val).lower() in str(signature_obj['name']).lower()]) == 0:
                     continue
             if 'match' in signature_obj:
-                parsed_signatures.append(SimpleMatch(signature_obj['part'],signature_obj['name'],signature_obj['match']))
+                parsed_signatures.append(SimpleMatch(signature_obj['part'], signature_obj['name'], signature_obj['match']))
             elif 'regex' in signature_obj:
-                parsed_signatures.append(RegexSignature(signature_obj['part'],signature_obj['name'],signature_obj['regex']))
+                parsed_signatures.append(RegexSignature(signature_obj['part'], signature_obj['name'], signature_obj['regex']))
             else:
-                module_logger.warning(f'No Match Method Of Access')
-            chosen_configs.append(signature_obj['name']+" In File "+signature_obj['part'])
-        
+                module_logger.warning('No Match Method Of Access')
+            chosen_configs.append(signature_obj['name'] + " In File " + signature_obj['part'])
+
         if len(user_filters) > 0:
-            module_logger.info('Applying Filtered Signatures : \n\n\t%s\n','\n\t'.join(chosen_configs))
+            module_logger.info('Applying Filtered Signatures : \n\n\t%s\n', '\n\t'.join(chosen_configs))
 
         return parsed_signatures
 
     @staticmethod
-    def create_matched_signature_object(name,part,file_path):
+    def create_matched_signature_object(name, part, file_path):
         return {
             'name': name,
             'part': part,

--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -144,9 +144,12 @@ class SignatureRecognizer:
         for signature_obj in raw_signatures:
             # $ Ignore Object if no Name/Part.
             if 'name' not in signature_obj or 'part' not in signature_obj:
+                module_logger.warn('Signature definition missing either name or part')
                 continue
             if len(user_filters) > 0:
                 if len([filtered_val for filtered_val in user_filters if str(filtered_val).lower() in str(signature_obj['name']).lower()]) == 0:
+                    module_logger.warning(f'Duplicate named used defined filter matching skipping '
+                                          f'adding {signature_obj["name"]} from config')
                     continue
             if 'match' in signature_obj:
                 parsed_signatures.append(SimpleMatch(signature_obj['part'], signature_obj['name'], signature_obj['match']))

--- a/test/test_load_signatures.py
+++ b/test/test_load_signatures.py
@@ -2,7 +2,8 @@ import unittest
 
 import yaml
 
-from tell_me_your_secrets.__main__ import SignatureRecognizer, DEFAULT_CONFIG_PATH
+from tell_me_your_secrets.__main__ import SignatureRecognizer
+from tell_me_your_secrets.defaults import DEFAULT_CONFIG_PATH
 
 
 class SignatureLoadTest(unittest.TestCase):

--- a/test/test_load_signatures.py
+++ b/test/test_load_signatures.py
@@ -1,0 +1,15 @@
+import unittest
+
+import yaml
+
+from tell_me_your_secrets.__main__ import SignatureRecognizer, DEFAULT_CONFIG_PATH
+
+
+class SignatureLoadTest(unittest.TestCase):
+
+    def test_load_default_config(self):
+        """ Test to ensure default config is valid. """
+        with open(DEFAULT_CONFIG_PATH) as f:
+            config = yaml.load(f, Loader=yaml.FullLoader)
+            signatures = SignatureRecognizer.load_signatures(config['signatures'], [])
+            self.assertTrue(len(signatures) > 0)


### PR DESCRIPTION
Added test that:

- Checks default config is valid YAML
- Checks that the signatures are parsed

Additional

- Add warning when failure to parse signature, or when filter overlaps - thanks @x-way 