### PR TITLE
Ensure wheel is setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -17,6 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools wheel
         pip install -r requirements.txt
     - name: Package
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel
+        pip install --upgrade setuptools wheel
         pip install -r requirements.txt
     - name: Package
       run: |


### PR DESCRIPTION
Looks like we forgot to include `wheel` on CI pipeline

See: https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives

- Rename `build` to `publish` 
- Ensure `setuptools` and `wheel` are installed to latest


You will need to delete the existing tag for `v1.78` and recreate from master after this merge