### PR TITLE
suppress logging + show match results.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tell-me-your-secrets"
-version = "2.4.1"
+version = "2.4.2"
 description = "A simple module which finds files with different secrets keys present inside a directory"
 authors = ["Valay Dave <valaygaurang@gmail.com>"]
 license = "MIT"

--- a/tell_me_your_secrets/__main__.py
+++ b/tell_me_your_secrets/__main__.py
@@ -161,7 +161,7 @@ class SignatureRecognizer:
         self.output_path = output_path
         # $ Make Configuration Objects For each of the Signatures in the Config Object.
         self.signatures: List[Signature] = self.load_signatures(config_object.get('signatures', {}), user_filters or [])
-        module_logger.info(f'Secret Sniffer Initialised For Path: {search_path}')
+        module_logger.debug(f'Secret Sniffer Initialised For Path: {search_path}')
 
     # $ Create the signature objects over here.
     @staticmethod
@@ -171,23 +171,23 @@ class SignatureRecognizer:
         for signature_obj in raw_signatures:
             # $ Ignore Object if no Name/Part.
             if 'name' not in signature_obj or 'part' not in signature_obj:
-                module_logger.warn('Signature definition missing either name or part')
+                module_logger.debug('Signature definition missing either name or part')
                 continue
             if len(user_filters) > 0:
                 if len([filtered_val for filtered_val in user_filters if str(filtered_val).lower() in str(signature_obj['name']).lower()]) == 0:
-                    module_logger.warning(f'Duplicate named used defined filter matching skipping '
-                                          f'adding {signature_obj["name"]} from config')
+                    module_logger.debug(f'Pattern did not match filters. Skipping filter matching '
+                                        f'for signature {signature_obj["name"]} from config')
                     continue
             if 'match' in signature_obj:
                 parsed_signatures.append(SimpleMatch(signature_obj['part'], signature_obj['name'], signature_obj['match']))
             elif 'regex' in signature_obj:
                 parsed_signatures.append(RegexSignature(signature_obj['part'], signature_obj['name'], signature_obj['regex']))
             else:
-                module_logger.warning('No Match Method Of Access')
+                module_logger.debug('No Match Method Of Access')
             chosen_configs.append(signature_obj['name'] + " In File " + signature_obj['part'])
 
         if len(user_filters) > 0:
-            module_logger.info('Applying Filtered Signatures : \n\n\t%s\n', '\n\t'.join(chosen_configs))
+            module_logger.debug('Applying Filtered Signatures : \n\n\t%s\n', '\n\t'.join(chosen_configs))
 
         return parsed_signatures
 
@@ -197,8 +197,7 @@ class SignatureRecognizer:
 
         self.process(filtered_files)
 
-        module_logger.info(f'Processed {len(filtered_files)} files and found {len(self.matched_signatures)} matches '
-                           f'from the search_path {self.search_path} in {self._get_time()} seconds')
+        module_logger.debug(f'Processed {len(filtered_files)} files and found {len(self.matched_signatures)} matches from the search_path {self.search_path} in {self._get_time()} seconds')
         if self.write_results:
             self.write_results_to_file()
 

--- a/tell_me_your_secrets/processor.py
+++ b/tell_me_your_secrets/processor.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from tell_me_your_secrets.logger import get_logger
 from tell_me_your_secrets.utils import get_file_data
@@ -10,11 +10,13 @@ class SignatureMatch:
     name: str
     part: str
     path: str
+    contents: Union[str, None]
 
-    def __init__(self, name: str, part: str, path: str):
+    def __init__(self, name: str, part: str, path: str, contents: Union[str, None] = None):
         self.name = name
         self.part = part
         self.path = path
+        self.contents = contents
 
 
 class Processor:
@@ -46,8 +48,8 @@ class Processor:
 
             if self.print_results:
                 module_logger.info(f'Signature Matched : {signature.name} | On Part : {signature.part} | With '
-                                   f'File : {file_path}')
+                                   f'File : {file_path} | Result : {match_result.matched_value}')
 
-            matches.append(SignatureMatch(signature.name, signature.part, file_path))
+            matches.append(SignatureMatch(signature.name, signature.part, file_path, match_result.matched_value))
 
         return matches

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -23,4 +23,4 @@ class WriteResultsTest(unittest.TestCase):
             ]
 
             signature_recognizer.write_results_to_file()
-            self.assertEqual(b',name,part,path\n0,Match,file,/path/to/file\n', output_file.read())
+            self.assertEqual(b',name,part,path,contents\n0,Match,file,/path/to/file,\n', output_file.read())


### PR DESCRIPTION
## Proposed change
First in the line of PRs to support #65. Moves lots of warnings and meaningless info to debug logs; Only logs info for signature matches. Also logs the matched content. This closes #61 

## How to test the change
Test it by running the code. 

## Checklist
-   [ ] Tests have been added to verify that the new code works (if possible)
-   [ ] Documentation has been updated to reflect changes
-   [ ] Changelog has been updated to reflect changes
